### PR TITLE
Wi-Fi network config for Ubuntu 16.04.

### DIFF
--- a/tools/NetworkManager/NetworkManager.conf
+++ b/tools/NetworkManager/NetworkManager.conf
@@ -1,0 +1,9 @@
+[main]
+plugins=ifupdown,keyfile,ofono
+dns=dnsmasq
+
+[ifupdown]
+managed=false
+
+[keyfile]
+unmanaged-devices=c4:e9:84:dc:42:b5

--- a/tools/dnsmasq/dnsmasq.conf
+++ b/tools/dnsmasq/dnsmasq.conf
@@ -22,7 +22,7 @@
 
 # Uncomment these to enable DNSSEC validation and caching:
 # (Requires dnsmasq to be built with DNSSEC option.)
-#conf-file=/usr/share/dnsmasq/trust-anchors.conf
+#conf-file=%%PREFIX%%/share/dnsmasq/trust-anchors.conf
 #dnssec
 
 # Replies which are not DNSSEC signed may be legitimate, because the domain
@@ -103,7 +103,7 @@
 # specified interfaces (and the loopback) give the name of the
 # interface (eg eth0) here.
 # Repeat the line for more than one interface.
-#interface=wlan0
+#interface=
 # Or you can specify which interface _not_ to listen on
 #except-interface=
 # Or which to listen on by address (remember to include 127.0.0.1 if

--- a/tools/network_interfaces/wlan0
+++ b/tools/network_interfaces/wlan0
@@ -1,0 +1,4 @@
+auto wlan0
+iface wlan0 inet static
+address 192.168.123.100
+netmask 255.255.255.0


### PR DESCRIPTION
Gets us back up to the point where we have a "Rover 12" wifi network which NATs through the ethernet port on the XU4.